### PR TITLE
Adds support for Safari on iOS, fixes #17

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<meta name="viewport" content="width=device-width">
 	<title>focus-options-polyfill</title>
 
 	<script src="./index.js"></script>
@@ -26,9 +27,21 @@
 		<button type="button" onclick="focusNoScrollMethod('focusable-button-1')">
 			Click me to focus on the button 1 without scrolling
 		</button>
+		
+		<div>
+			<button type="button" onclick="focusScrollMethod('focusable-input-1')">
+				Click me to focus on the input 4
+			</button>
+			<button type="button" onclick="focusNoScrollMethod('focusable-input-1')">
+				Click me to focus on the input 4 without scrolling
+			</button>
+		</div>
 
 		<div class="container">
 			<button type="button" id="focusable-button-1" style="margin-top: 1500px;">Button 1</button>
+
+			<!-- The font size needs to be over 16px to stop zooming on iOS -->
+			<input type="text" id="focusable-input-1" style="margin-top: 1500px; font-size: 24px;">
 		</div>
 
 	</article>

--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@
         if (typeof setTimeout === 'function') {
           setTimeout(function () {
             restoreScrollPosition(evScrollableElements);
-          }, 100);
+          }, 0);
         } else {
           restoreScrollPosition(evScrollableElements);          
         }

--- a/index.js
+++ b/index.js
@@ -70,11 +70,11 @@
     var patchedFocus = function(args) {
       if (args && args.preventScroll) {
         var evScrollableElements = calcScrollableElements(this);
-        this.nativeFocus()
+        this.nativeFocus();
         if (typeof setTimeout === 'function') {
           setTimeout(function () {
             restoreScrollPosition(evScrollableElements);
-          }, 100)
+          }, 100);
         } else {
           restoreScrollPosition(evScrollableElements);          
         }

--- a/index.js
+++ b/index.js
@@ -70,8 +70,14 @@
     var patchedFocus = function(args) {
       if (args && args.preventScroll) {
         var evScrollableElements = calcScrollableElements(this);
-        this.nativeFocus();
-        restoreScrollPosition(evScrollableElements);
+        this.nativeFocus()
+        if (typeof setTimeout === 'function') {
+          setTimeout(function () {
+            restoreScrollPosition(evScrollableElements);
+          }, 100)
+        } else {
+          restoreScrollPosition(evScrollableElements);          
+        }
       }
       else {
         this.nativeFocus();


### PR DESCRIPTION
I was able to reproduce the issue described in #17 using Safari on iOS 13.

The support check seemed correct from my testing, and all that was missing was a timeout so `restoreScrollPosition` will happen after `nativeFocus`.

This PR adds a 100ms timeout, which fixes the issue. Some comments on [this Stack Overflow post](https://stackoverflow.com/questions/4963053/focus-to-input-without-scrolling#comment23543573_6610501) suggest that’s also necessary for older versions of IE.

![focus-options-polyfill-test](https://user-images.githubusercontent.com/1581276/85315302-a7ee4000-b46f-11ea-87ad-38131c2519c5.gif)

I also updated the test case to add an input, which worked better as a test for touch devices. When the polyfill is working, the keyboard will open automatically.

