### PR TITLE
Fixes Edge bug with inputs and textareas

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ https://caniuse.com/#feat=mdn-api_htmlelement_focus_preventscroll_option
 
 * Edge: Issue 14314565 - Enable ability to prevent scrolling in Element.focus()
 
-  https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/14314565/
+  https://web.archive.org/web/20190401133643/https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/14314565/
 
 * Firefox: Bug 1374045 - Consider adding support for customizing scrolling behavior with Element.focus
 

--- a/index.js
+++ b/index.js
@@ -22,6 +22,15 @@
     focusElem.focus(
       Object.defineProperty({}, "preventScroll", {
         get: function() {
+          // Edge v18 gives a false positive for supporting inputs
+          if (
+            navigator &&
+            typeof navigator.userAgent !== 'undefined' &&
+            navigator.userAgent &&
+            navigator.userAgent.match(/Edge\/1[7-8]/)) {
+              return supportsPreventScrollOption = false
+          }
+
           supportsPreventScrollOption = true;
         }
       })


### PR DESCRIPTION
I happened to see some inconsistent results with this polyfill on Edge v18.

- Edge does support [the main test for this feature](https://wpt.live/html/interaction/focus/processing-model/preventScroll.html), but doesn’t prevent scrolling for text inputs and textareas.
- Edge fails this more recent web platform test that checks for that: https://wpt.live/html/interaction/focus/processing-model/preventScroll-textarea.html (note you have to scroll down, it looks like a blank page, but it isn’t)

I am doing some very light user agent checking to resolve this, which is obviously not ideal, but I couldn’t find another way to solve the problem since Edge does partially support `focusOptions`.

There’s also a tradeoff in that the polyfill is then used for everything, so you get a brief “flash” when the scrolling is prevented. That part is similar to what we saw on Safari, because it also needs the `setTimeout`.

Let me know what you think of this solution!

### Without the polyfill

Doesn’t work the text inputs, but works natively on the button.

![edge18-without-fix](https://user-images.githubusercontent.com/1581276/89821892-2c6e4e00-db04-11ea-9aff-b583f9773da8.gif)

### With the polyfill, and this fix

Works on both.

![edge18-with-fix-both](https://user-images.githubusercontent.com/1581276/89821896-2d9f7b00-db04-11ea-8f62-f6b057aec644.gif)
