### PR TITLE
Avoid flash effect on scroll restoration

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,13 +79,15 @@
     var patchedFocus = function(args) {
       if (args && args.preventScroll) {
         var evScrollableElements = calcScrollableElements(this);
-        this.nativeFocus();
         if (typeof setTimeout === 'function') {
+          var thisElem = this;
           setTimeout(function () {
+            thisElem.nativeFocus();
             restoreScrollPosition(evScrollableElements);
           }, 0);
         } else {
-          restoreScrollPosition(evScrollableElements);          
+          this.nativeFocus();
+          restoreScrollPosition(evScrollableElements);
         }
       }
       else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "focus-options-polyfill",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "focus-options-polyfill",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "description": "JavaScript polyfill for the WHATWG spec of focusOptions, that enables a set of options to be passed to the focus method.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
These changes try to avoid the flash effect (commented in #22 or #18) that can occur when the polyfill is used under some circumstances.

It does this by moving `nativeFocus` execution as close as possible to scroll restoration, so the delay between them is minimum and not perceivable to the human eye.